### PR TITLE
Add new SenderOptionFunc to allow overriding default drainDuration

### DIFF
--- a/logziosender.go
+++ b/logziosender.go
@@ -103,6 +103,14 @@ func SetDebug(debug io.Writer) SenderOptionFunc {
 	}
 }
 
+// SetDrainDuration to change the interval between drains
+func SetDrainDuration(duration time.Duration) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.drainDuration = duration
+		return nil
+	}
+}
+
 // Send the payload to logz.io
 func (l *LogzioSender) Send(payload []byte) error {
 	_, err := l.queue.Enqueue(payload)


### PR DESCRIPTION
Hello there!

First of all, thanks for creating this library. It definitely makes it easier for us to ship logs (robustly) off to logz.io, so your effort in creating this is greatly appreciated.

One thing we noticed that we are unable to do is override the `drainDuration` delay interval from the default 5 seconds. This PR allows for overriding that following the same pattern of using `SenderOptionFunc`.

Let me know what you think. Thanks!